### PR TITLE
Data source cleanup

### DIFF
--- a/apps/web/src/app/actions/get-data-sources.ts
+++ b/apps/web/src/app/actions/get-data-sources.ts
@@ -17,7 +17,7 @@ export async function getDataSources(): Promise<DataSourceInfo[]> {
     }
 
     return {
-      id: ds.id,
+      type: ds.type,
       name: ds.name,
       description: ds.description,
       fields,

--- a/apps/web/src/app/common/data-source-info.ts
+++ b/apps/web/src/app/common/data-source-info.ts
@@ -5,7 +5,7 @@ export type FieldInfo = {
 };
 
 export type DataSourceInfo = {
-  id: string;
+  type: string;
   name: string;
   description?: string;
   fields: FieldInfo[];

--- a/apps/web/src/app/components/DataSourceManager.tsx
+++ b/apps/web/src/app/components/DataSourceManager.tsx
@@ -34,7 +34,7 @@ export function DataSourceManager({
         <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
           {dataSources.map((dataSource) => (
             <button
-              key={dataSource.id}
+              key={dataSource.type}
               onClick={() => handleButtonClick(dataSource)}
             >
               <div>{dataSource.name}</div>

--- a/packages/data-sources/bigquery/src/bigquery-datasource.ts
+++ b/packages/data-sources/bigquery/src/bigquery-datasource.ts
@@ -3,7 +3,7 @@ import { type DataSource, registry } from '@contexthub/data-sources-common';
 export class BigQueryDataSource implements DataSource {
   private credentials: Record<string, string>;
 
-  constructor(credentials: Record<string, string>) {
+  constructor({ credentials }: { credentials: Record<string, string> }) {
     for (const field of credentialsFields) {
       if (field.isRequired && !credentials[field.name]) {
         throw new Error(`Missing required field ${field.name}`);
@@ -21,9 +21,9 @@ export class BigQueryDataSource implements DataSource {
 const credentialsFields = [{ name: 'credentialsJson', isRequired: true }];
 
 registry.register({
-  id: 'bigquery',
+  type: 'bigquery',
   name: 'BigQuery',
   credentialsFields,
-  factory: (credentials: Record<string, string>) =>
-    new BigQueryDataSource(credentials),
+  factory: ({ credentials }: { credentials: Record<string, string> }) =>
+    new BigQueryDataSource({ credentials }),
 });

--- a/packages/data-sources/common/src/registry.ts
+++ b/packages/data-sources/common/src/registry.ts
@@ -1,42 +1,69 @@
 import { DataSource } from '@contexthub/data-sources-common';
 
 export interface DataSourceRegistration {
-  id: string;
+  /**
+   * For example: "bigquery", "snowflake".
+   */
+  type: string;
+  /**
+   * A human-readable name for the data source. This is
+   * used to identify the data source in the UI.
+   */
   name: string;
+  /**
+   * A human-readable description of the data source. This is
+   * used to describe the data source in the UI.
+   */
   description?: string;
+  /**
+   * The fields required to connect to the data source.
+   */
   credentialsFields: {
     name: string;
     description?: string;
     isRequired: boolean;
   }[];
-  factory: (credentials: Record<string, string>) => DataSource;
+  /**
+   * A factory function that creates a new instance of the data source.
+   */
+  factory: ({
+    credentials,
+  }: {
+    credentials: Record<string, string>;
+  }) => DataSource;
 }
 
 class DataSourceRegistry {
   private sources = new Map<string, DataSourceRegistration>();
 
   register(registration: DataSourceRegistration) {
-    if (this.sources.has(registration.id)) {
-      throw new Error(`Data source ${registration.id} already registered`);
+    if (this.sources.has(registration.type)) {
+      throw new Error(`Data source ${registration.type} already registered`);
     }
-    this.sources.set(registration.id, registration);
+    this.sources.set(registration.type, registration);
   }
 
-  get(id: string): DataSourceRegistration | undefined {
-    return this.sources.get(id);
+  get({ type }: { type: string }): DataSourceRegistration | null {
+    return this.sources.get(type) ?? null;
   }
 
   getAll(): DataSourceRegistration[] {
     return Array.from(this.sources.values());
   }
 
-  createInstance(id: string, credentials: Record<string, string>): DataSource {
-    const registration = this.sources.get(id);
+  createInstance({
+    type,
+    credentials,
+  }: {
+    type: string;
+    credentials: Record<string, string>;
+  }): DataSource {
+    const registration = this.sources.get(type);
     if (!registration) {
-      throw new Error(`Data source ${id} not found`);
+      throw new Error(`Data source ${type} not found`);
     }
 
-    return registration.factory(credentials);
+    return registration.factory({ credentials });
   }
 }
 

--- a/packages/data-sources/snowflake/src/snowflake-datasource.ts
+++ b/packages/data-sources/snowflake/src/snowflake-datasource.ts
@@ -3,7 +3,7 @@ import { type DataSource, registry } from '@contexthub/data-sources-common';
 export class SnowflakeDataSource implements DataSource {
   private credentials: Record<string, string>;
 
-  constructor(credentials: Record<string, string>) {
+  constructor({ credentials }: { credentials: Record<string, string> }) {
     for (const field of credentialsFields) {
       if (field.isRequired && !credentials[field.name]) {
         throw new Error(`Missing required field ${field.name}`);
@@ -24,9 +24,9 @@ const credentialsFields = [
 ];
 
 registry.register({
-  id: 'snowflake',
+  type: 'snowflake',
   name: 'Snowflake',
   credentialsFields,
-  factory: (credentials: Record<string, string>) =>
-    new SnowflakeDataSource(credentials),
+  factory: ({ credentials }: { credentials: Record<string, string> }) =>
+    new SnowflakeDataSource({ credentials }),
 });


### PR DESCRIPTION
- Named params
- Call it `type` instead of `id` so that we don't confuse with the database id.