### PR TITLE
Job heartbeat

### DIFF
--- a/packages/job-queue/src/index.ts
+++ b/packages/job-queue/src/index.ts
@@ -1,3 +1,10 @@
-export { enqueue, claimOne, completeJob, failJob, listJobs } from './queue.js';
+export {
+  enqueue,
+  claimOne,
+  completeJob,
+  failJob,
+  listJobs,
+  heartbeat,
+} from './queue.js';
 export type { Job } from './types.js';
 export { QUEUES } from './types.js';

--- a/packages/job-queue/src/queue.ts
+++ b/packages/job-queue/src/queue.ts
@@ -141,3 +141,21 @@ export async function failJob({
     data: { lockedAt: null, lastError: error, runAt: nextRunAt },
   });
 }
+
+/**
+ * Heartbeats a job.
+ *
+ * This prevents long running jobs to be claimed again by another worker.
+ *
+ * @param prisma - The Prisma client to use.
+ * @param id - The ID of the job to heartbeat.
+ */
+export async function heartbeat({
+  prisma = defaultPrisma,
+  id,
+}: {
+  prisma?: PrismaClient;
+  id: string;
+}): Promise<void> {
+  await prisma.job.update({ where: { id }, data: { lockedAt: new Date() } });
+}


### PR DESCRIPTION
Makes long running jobs possible without having to extend visibility timeouts excessively.