### PR TITLE
Context engine simplification

### DIFF
--- a/packages/context-agent/package.json
+++ b/packages/context-agent/package.json
@@ -18,7 +18,8 @@
     "@contexthub/core": "workspace:*",
     "@contexthub/database": "workspace:*",
     "@openai/agents": "0.0.14",
-    "zod": "3.25.66"
+    "zod": "3.25.66",
+    "dotenv": "^17.2.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/context-agent/src/index.ts
+++ b/packages/context-agent/src/index.ts
@@ -1,10 +1,5 @@
 // Types and interfaces
-export type {
-  GenerateTableContextInput,
-  GenerateColumnContextInput,
-  TableContextResult,
-  ColumnContextResult,
-} from './types.js';
+export type { GenerateTableContextInput, TableContextResult } from './types.js';
 
 // Context engine interface
 export type { ContextEngine } from './context-engine.js';

--- a/packages/context-agent/src/openai-agent-context-engine.ts
+++ b/packages/context-agent/src/openai-agent-context-engine.ts
@@ -43,11 +43,9 @@ export class OpenAIAgentContextEngine implements ContextEngine {
     private readonly config: { model: string }
   ) {
     // Get tools from current context source
-    const tools: Tool[] = [];
-    for (const source of this.contextSources) {
-      const toolsForSource = source.getTools();
-      tools.push(...toolsForSource);
-    }
+    const tools: Tool[] = this.contextSources.flatMap((source) =>
+      source.getTools()
+    );
     // Create agent with current source's tools
     this.tableContextAgent = new Agent<
       typeof OpenAIAgentContextEngine.tableContextAgentInputSchema,

--- a/packages/context-agent/src/test-openai-agent-context-engine.ts
+++ b/packages/context-agent/src/test-openai-agent-context-engine.ts
@@ -73,7 +73,39 @@ async function testOpenAIAgentContextEngine() {
       isNullable: false,
       dataType: 'varchar',
       columnDefault: null,
-      fullyQualifiedTableName: tableDefinition.fullyQualifiedTableName,
+  const baseColumnProps = {
+    tableName: tableDefinition.tableName,
+    tableSchema: tableDefinition.tableSchema,
+    tableCatalog: tableDefinition.tableCatalog,
+    fullyQualifiedTableName: tableDefinition.fullyQualifiedTableName,
+  };
+
+  const columnDefinitions: ColumnDefinition[] = [
+    {
+      ...baseColumnProps,
+      columnName: 'id',
+      ordinalPosition: 1,
+      isNullable: false,
+      dataType: 'integer',
+      columnDefault: null,
+      fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.id`,
+    },
+    {
+      ...baseColumnProps,
+      columnName: 'username',
+      ordinalPosition: 2,
+      isNullable: false,
+      dataType: 'varchar',
+      columnDefault: null,
+      fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.username`,
+    },
+    {
+      ...baseColumnProps,
+      columnName: 'email',
+      ordinalPosition: 3,
+      isNullable: false,
+      dataType: 'varchar',
+      columnDefault: null,
       fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.email`,
     },
     {

--- a/packages/context-agent/src/test-openai-agent-context-engine.ts
+++ b/packages/context-agent/src/test-openai-agent-context-engine.ts
@@ -39,11 +39,16 @@ async function testOpenAIAgentContextEngine() {
     fullyQualifiedTableName: 'my_database.public.users',
   };
 
+  const baseColumnProps = {
+    tableName: tableDefinition.tableName,
+    tableSchema: tableDefinition.tableSchema,
+    tableCatalog: tableDefinition.tableCatalog,
+    fullyQualifiedTableName: tableDefinition.fullyQualifiedTableName,
+  };
+
   const columnDefinitions: ColumnDefinition[] = [
     {
-      tableName: tableDefinition.tableName,
-      tableSchema: tableDefinition.tableSchema,
-      tableCatalog: tableDefinition.tableCatalog,
+      ...baseColumnProps,
       columnName: 'id',
       ordinalPosition: 1,
       isNullable: false,
@@ -53,9 +58,7 @@ async function testOpenAIAgentContextEngine() {
       fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.id`,
     },
     {
-      tableName: tableDefinition.tableName,
-      tableSchema: tableDefinition.tableSchema,
-      tableCatalog: tableDefinition.tableCatalog,
+      ...baseColumnProps,
       columnName: 'username',
       ordinalPosition: 2,
       isNullable: false,
@@ -65,9 +68,7 @@ async function testOpenAIAgentContextEngine() {
       fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.username`,
     },
     {
-      tableName: tableDefinition.tableName,
-      tableSchema: tableDefinition.tableSchema,
-      tableCatalog: tableDefinition.tableCatalog,
+      ...baseColumnProps,
       columnName: 'email',
       ordinalPosition: 3,
       isNullable: false,
@@ -77,9 +78,7 @@ async function testOpenAIAgentContextEngine() {
       fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.email`,
     },
     {
-      tableName: tableDefinition.tableName,
-      tableSchema: tableDefinition.tableSchema,
-      tableCatalog: tableDefinition.tableCatalog,
+      ...baseColumnProps,
       columnName: 'created_at',
       ordinalPosition: 4,
       isNullable: false,
@@ -89,9 +88,7 @@ async function testOpenAIAgentContextEngine() {
       fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.created_at`,
     },
     {
-      tableName: tableDefinition.tableName,
-      tableSchema: tableDefinition.tableSchema,
-      tableCatalog: tableDefinition.tableCatalog,
+      ...baseColumnProps,
       columnName: 'updated_at',
       ordinalPosition: 5,
       isNullable: false,
@@ -101,9 +98,7 @@ async function testOpenAIAgentContextEngine() {
       fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.updated_at`,
     },
     {
-      tableName: tableDefinition.tableName,
-      tableSchema: tableDefinition.tableSchema,
-      tableCatalog: tableDefinition.tableCatalog,
+      ...baseColumnProps,
       columnName: 'status',
       ordinalPosition: 6,
       isNullable: false,

--- a/packages/context-agent/src/test-openai-agent-context-engine.ts
+++ b/packages/context-agent/src/test-openai-agent-context-engine.ts
@@ -62,7 +62,7 @@ async function testOpenAIAgentContextEngine() {
       dataType: 'varchar',
       columnDefault: null,
       fullyQualifiedTableName: tableDefinition.fullyQualifiedTableName,
-      fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.name`,
+      fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.username`,
     },
     {
       tableName: tableDefinition.tableName,

--- a/packages/context-agent/src/test-openai-agent-context-engine.ts
+++ b/packages/context-agent/src/test-openai-agent-context-engine.ts
@@ -73,39 +73,7 @@ async function testOpenAIAgentContextEngine() {
       isNullable: false,
       dataType: 'varchar',
       columnDefault: null,
-  const baseColumnProps = {
-    tableName: tableDefinition.tableName,
-    tableSchema: tableDefinition.tableSchema,
-    tableCatalog: tableDefinition.tableCatalog,
-    fullyQualifiedTableName: tableDefinition.fullyQualifiedTableName,
-  };
-
-  const columnDefinitions: ColumnDefinition[] = [
-    {
-      ...baseColumnProps,
-      columnName: 'id',
-      ordinalPosition: 1,
-      isNullable: false,
-      dataType: 'integer',
-      columnDefault: null,
-      fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.id`,
-    },
-    {
-      ...baseColumnProps,
-      columnName: 'username',
-      ordinalPosition: 2,
-      isNullable: false,
-      dataType: 'varchar',
-      columnDefault: null,
-      fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.username`,
-    },
-    {
-      ...baseColumnProps,
-      columnName: 'email',
-      ordinalPosition: 3,
-      isNullable: false,
-      dataType: 'varchar',
-      columnDefault: null,
+      fullyQualifiedTableName: tableDefinition.fullyQualifiedTableName,
       fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.email`,
     },
     {

--- a/packages/context-agent/src/test-openai-agent-context-engine.ts
+++ b/packages/context-agent/src/test-openai-agent-context-engine.ts
@@ -1,125 +1,144 @@
+import 'dotenv/config';
 import { OpenAIAgentContextEngine } from './openai-agent-context-engine.js';
-import type { TableDefinition } from '@contexthub/core';
+import type { ColumnDefinition, TableDefinition } from '@contexthub/core';
 import { InMemoryTextInputContextSource } from '@contexthub/context-sources-all';
 
 // Test function
 async function testOpenAIAgentContextEngine() {
-  console.log(
-    '🚀 Starting OpenAIAgentContextEngine test with InMemoryTextInputContextSource...\n'
-  );
-
-  try {
-    // Check if OpenAI API key is available
-    const apiKey = process.env.OPENAI_API_KEY;
-    if (!apiKey) {
-      console.log('⚠️  OPENAI_API_KEY not found in environment variables');
-      console.log(
-        "   This test will show the structure but won't make actual API calls"
-      );
-      console.log('   Set OPENAI_API_KEY to test with real OpenAI API\n');
-    } else {
-      console.log('✅ OpenAI API key found\n');
-    }
-
-    // Create context sources using InMemoryTextInputContextSource
-    const contextSources = [
-      new InMemoryTextInputContextSource({
-        text: 'The users table stores user account information including profile details, authentication data, and account settings. It is used for user management, authentication, and personalization features.',
-        description: 'Documentation about the users table',
-      }),
-      new InMemoryTextInputContextSource({
-        text: 'The table contains columns: id (primary key), username, email, created_at, updated_at, and status. The id column is auto-incrementing, email must be unique, and status can be active, inactive, or pending.',
-        description: 'Schema analysis of the users table',
-      }),
-      new InMemoryTextInputContextSource({
-        text: 'This table is frequently queried for user authentication, profile management, and account status checks. Common queries include finding users by email, checking account status, and retrieving user profiles.',
-        description: 'Usage patterns and common queries',
-      }),
-    ];
-
-    // Create test table definition
-    const testTable: TableDefinition = {
-      tableName: 'users',
-      tableSchema: 'public',
-      tableCatalog: 'my_database',
-      fullyQualifiedTableName: 'my_database.public.users',
-    };
-
-    console.log('📋 Test Configuration:');
-    console.log('   Table:', testTable.tableName);
-    console.log('   Schema:', testTable.tableSchema);
-    console.log('   Context Sources:', contextSources.length);
-    console.log('');
-
-    if (apiKey) {
-      // Create context engine (no constructor parameters needed)
-      const contextEngine = new OpenAIAgentContextEngine();
-
-      console.log('🔄 Generating table context...\n');
-
-      // Generate context
-      const result = await contextEngine.generateTableContext({
-        dataSourceConnectionId: 'ds1',
-        table: testTable,
-        contextSources: contextSources,
-      });
-
-      console.log('✅ Context Generation Complete!\n');
-      console.log('📊 Results:');
-      console.log('   Sources Used:', result.sourcesUsed.join(', '));
-      console.log('   Description:', result.context.description);
-      console.log('');
-    } else {
-      // Show structure without making API calls
-      console.log('📋 Test Structure (without API calls):');
-      console.log('   - InMemoryTextInputContextSource instances created');
-      console.log('   - Table definition prepared');
-      console.log('   - Context engine would process sources iteratively');
-      console.log('   - Final synthesis would combine all context');
-      console.log('');
-
-      // Test tool generation from context sources
-      console.log('🔧 Testing tool generation from context sources:');
-      for (const source of contextSources) {
-        try {
-          const tools = await source.getTools();
-          console.log(
-            `   ✅ ${source.constructor.name}: ${tools.length} tools generated`
-          );
-
-          // Show tool details
-          for (const tool of tools) {
-            if (tool.type === 'function') {
-              console.log(`      - Tool: ${tool.name}`);
-              console.log(`      - Description: ${tool.description}`);
-            }
-          }
-        } catch (error) {
-          console.log(
-            `   ❌ ${source.constructor.name}: Error generating tools -`,
-            error
-          );
-        }
-      }
-      console.log('');
-
-      // Test creating new context sources
-      console.log('🔧 Testing context source creation:');
-      const newSource = new InMemoryTextInputContextSource({
-        text: 'This is a test text input for the context source.',
-        description: 'Test description',
-      });
-      console.log(
-        '   ✅ Successfully created and configured new context source'
-      );
-      console.log('');
-    }
-
-    console.log('🎉 Test completed successfully!');
-  } catch (error) {
-    console.error('❌ Test failed:', error);
-    process.exit(1);
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('OPENAI_API_KEY not found in environment variables');
   }
+  if (!process.env.OPENAI_MODEL) {
+    throw new Error('OPENAI_MODEL not found in environment variables');
+  }
+
+  // Create context sources using InMemoryTextInputContextSource
+  const contextSources = [
+    new InMemoryTextInputContextSource({
+      name: 'Users table documentation',
+      text: 'The users table stores user account information including profile details, authentication data, and account settings. It is used for user management, authentication, and personalization features.',
+      description: 'Documentation about the users table',
+    }),
+    new InMemoryTextInputContextSource({
+      name: 'Users table schema',
+      text: 'The table contains columns: id (primary key), username, email, created_at, updated_at, and status. The id column is auto-incrementing, email must be unique, and status can be active, inactive, or pending.',
+      description: 'Schema analysis of the users table',
+    }),
+    new InMemoryTextInputContextSource({
+      name: 'Users table usage patterns',
+      text: 'This table is frequently queried for user authentication, profile management, and account status checks. Common queries include finding users by email, checking account status, and retrieving user profiles.',
+      description: 'Usage patterns and common queries',
+    }),
+  ];
+
+  // Create test table definition
+  const tableDefinition: TableDefinition = {
+    tableName: 'users',
+    tableSchema: 'public',
+    tableCatalog: 'my_database',
+    fullyQualifiedTableName: 'my_database.public.users',
+  };
+
+  const columnDefinitions: ColumnDefinition[] = [
+    {
+      tableName: tableDefinition.tableName,
+      tableSchema: tableDefinition.tableSchema,
+      tableCatalog: tableDefinition.tableCatalog,
+      columnName: 'id',
+      ordinalPosition: 1,
+      isNullable: false,
+      dataType: 'integer',
+      columnDefault: null,
+      fullyQualifiedTableName: tableDefinition.fullyQualifiedTableName,
+      fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.id`,
+    },
+    {
+      tableName: tableDefinition.tableName,
+      tableSchema: tableDefinition.tableSchema,
+      tableCatalog: tableDefinition.tableCatalog,
+      columnName: 'username',
+      ordinalPosition: 2,
+      isNullable: false,
+      dataType: 'varchar',
+      columnDefault: null,
+      fullyQualifiedTableName: tableDefinition.fullyQualifiedTableName,
+      fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.name`,
+    },
+    {
+      tableName: tableDefinition.tableName,
+      tableSchema: tableDefinition.tableSchema,
+      tableCatalog: tableDefinition.tableCatalog,
+      columnName: 'email',
+      ordinalPosition: 3,
+      isNullable: false,
+      dataType: 'varchar',
+      columnDefault: null,
+      fullyQualifiedTableName: tableDefinition.fullyQualifiedTableName,
+      fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.email`,
+    },
+    {
+      tableName: tableDefinition.tableName,
+      tableSchema: tableDefinition.tableSchema,
+      tableCatalog: tableDefinition.tableCatalog,
+      columnName: 'created_at',
+      ordinalPosition: 4,
+      isNullable: false,
+      dataType: 'timestamp',
+      columnDefault: null,
+      fullyQualifiedTableName: tableDefinition.fullyQualifiedTableName,
+      fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.created_at`,
+    },
+    {
+      tableName: tableDefinition.tableName,
+      tableSchema: tableDefinition.tableSchema,
+      tableCatalog: tableDefinition.tableCatalog,
+      columnName: 'updated_at',
+      ordinalPosition: 5,
+      isNullable: false,
+      dataType: 'timestamp',
+      columnDefault: null,
+      fullyQualifiedTableName: tableDefinition.fullyQualifiedTableName,
+      fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.updated_at`,
+    },
+    {
+      tableName: tableDefinition.tableName,
+      tableSchema: tableDefinition.tableSchema,
+      tableCatalog: tableDefinition.tableCatalog,
+      columnName: 'status',
+      ordinalPosition: 6,
+      isNullable: false,
+      dataType: 'varchar',
+      columnDefault: null,
+      fullyQualifiedTableName: tableDefinition.fullyQualifiedTableName,
+      fullyQualifiedColumnName: `${tableDefinition.fullyQualifiedTableName}.status`,
+    },
+  ];
+
+  console.log('📋 Test Configuration:');
+  console.log('   Table:', tableDefinition.tableName);
+  console.log('   Schema:', tableDefinition.tableSchema);
+  console.log('   Columns:', columnDefinitions.length);
+  console.log('   Context Sources:', contextSources.length);
+  console.log('');
+
+  // Create context engine (no constructor parameters needed)
+  const contextEngine = new OpenAIAgentContextEngine(contextSources, {
+    model: process.env.OPENAI_MODEL,
+  });
+
+  console.log('🔄 Generating table context...\n');
+
+  // Generate context
+  const result = await contextEngine.generateTableContext({
+    dataSourceConnectionId: 'ds1',
+    dataSourceConnectionName: 'data warehouse',
+    tableDefinition,
+    columnDefinitions,
+    existingTableContext: null,
+    existingColumnContexts: [],
+  });
+
+  console.log(JSON.stringify(result, null, 2));
 }
 
 // Run the test

--- a/packages/context-agent/src/types.ts
+++ b/packages/context-agent/src/types.ts
@@ -4,7 +4,6 @@ import type {
   TableContext,
   ColumnContext,
 } from '@contexthub/core';
-import type { ContextSource } from '@contexthub/context-sources-all';
 import z from 'zod';
 
 /**
@@ -16,38 +15,26 @@ export interface GenerateTableContextInput {
    */
   dataSourceConnectionId: string;
   /**
+   * The name of the data source connection this context is associated with.
+   * This can be used to identify the data source in question when using context sources.
+   */
+  dataSourceConnectionName: string;
+  /**
    * The table definition to generate context for
    */
-  table: TableDefinition;
-
+  tableDefinition: TableDefinition;
   /**
-   * List of context sources to use for inference
+   * The columns to generate context for.
    */
-  contextSources: ContextSource[];
-}
-
-/**
- * Input for generating column context
- */
-export interface GenerateColumnContextInput {
+  columnDefinitions: ColumnDefinition[];
   /**
-   * The id of the data source connection this context is associated with.
+   * Existing table context to use as a starting point.
    */
-  dataSourceConnectionId: string;
+  existingTableContext: TableContext | null;
   /**
-   * The column definition to generate context for
+   * Existing column context to use as a starting point.
    */
-  column: ColumnDefinition;
-
-  /**
-   * The table this column belongs to
-   */
-  table: TableDefinition;
-
-  /**
-   * List of context sources to use for inference
-   */
-  contextSources: ContextSource[];
+  existingColumnContexts: ColumnContext[];
 }
 
 /**
@@ -55,34 +42,13 @@ export interface GenerateColumnContextInput {
  */
 export interface TableContextResult {
   /**
-   * The original table definition
-   */
-  table: TableDefinition;
-
-  /**
    * Generated table context
    */
-  context: TableContext;
-
+  newTableContext: TableContext;
   /**
-   * Sources used to generate this context
+   * Generated column contexts
    */
-  sourcesUsed: string[];
-}
-
-/**
- * Result of column context generation
- */
-export interface ColumnContextResult {
-  /**
-   * The original column definition
-   */
-  column: ColumnDefinition;
-
-  /**
-   * Generated column context
-   */
-  context: ColumnContext;
+  newColumnContexts: ColumnContext[];
 }
 
 export const contextAgentResultSchema = z.object({

--- a/packages/context-sources/text/src/in-memory-text-input-context-source.ts
+++ b/packages/context-sources/text/src/in-memory-text-input-context-source.ts
@@ -7,15 +7,18 @@ import {
 import { z } from 'zod';
 
 export interface InMemoryTextInputConfig {
+  name: string;
   text: string;
   description?: string;
 }
 
 export class InMemoryTextInputContextSource implements ContextSource {
+  private name: string;
   private text: string = '';
   private description: string = '';
 
-  constructor({ text, description }: InMemoryTextInputConfig) {
+  constructor({ name, text, description }: InMemoryTextInputConfig) {
+    this.name = name;
     this.text = text;
     this.description = description || '';
   }
@@ -23,7 +26,7 @@ export class InMemoryTextInputContextSource implements ContextSource {
   getTools(): Tool[] {
     return [
       tool({
-        name: 'get_text_content',
+        name: `${this.name}.get_content`,
         description: this.description || 'Get the stored text content',
         parameters: z.object({}).strict(),
         execute: async () => {
@@ -37,14 +40,19 @@ export class InMemoryTextInputContextSource implements ContextSource {
 registry.register({
   type: 'text',
   factory: ({ configuration }: { configuration: Record<string, string> }) => {
+    const name = configuration.name;
     const text = configuration.text;
     const description = configuration.description;
 
     if (!text) {
       throw new Error('Text is required');
     }
+    if (!name) {
+      throw new Error('Name is required');
+    }
 
     return new InMemoryTextInputContextSource({
+      name,
       text,
       description,
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       '@openai/agents':
         specifier: 0.0.14
         version: 0.0.14(ws@8.18.3)(zod@3.25.66)
+      dotenv:
+        specifier: ^17.2.0
+        version: 17.2.0
       zod:
         specifier: 3.25.66
         version: 3.25.66


### PR DESCRIPTION
- Instead of looping through the context sources and synthesizing in the end, just have the agent decide which context sources to call.
- Keep the same agent across calls, so that it can retain memory.
- Do context for a table and its columns in the same call.
- Pass in existing context so that the agent doesn't reinvent the context but rather is economical about diffs