### PR TITLE
Name in context source

### DIFF
--- a/apps/web/src/app/agents/context-sources/connect-context-source.ts
+++ b/apps/web/src/app/agents/context-sources/connect-context-source.ts
@@ -17,6 +17,7 @@ export async function connectContextSource({
     // Make sure we can create an instance before saving.
     registry.createInstance({
       type,
+      name,
       configuration,
     });
   } catch (error) {

--- a/packages/context-agent/src/test-openai-agent-context-engine.ts
+++ b/packages/context-agent/src/test-openai-agent-context-engine.ts
@@ -24,14 +24,17 @@ async function testOpenAIAgentContextEngine() {
     // Create context sources using InMemoryTextInputContextSource
     const contextSources = [
       new InMemoryTextInputContextSource({
+        name: 'Users table documentation',
         text: 'The users table stores user account information including profile details, authentication data, and account settings. It is used for user management, authentication, and personalization features.',
         description: 'Documentation about the users table',
       }),
       new InMemoryTextInputContextSource({
+        name: 'Users table schema',
         text: 'The table contains columns: id (primary key), username, email, created_at, updated_at, and status. The id column is auto-incrementing, email must be unique, and status can be active, inactive, or pending.',
         description: 'Schema analysis of the users table',
       }),
       new InMemoryTextInputContextSource({
+        name: 'Users table usage patterns',
         text: 'This table is frequently queried for user authentication, profile management, and account status checks. Common queries include finding users by email, checking account status, and retrieving user profiles.',
         description: 'Usage patterns and common queries',
       }),
@@ -106,6 +109,7 @@ async function testOpenAIAgentContextEngine() {
       // Test creating new context sources
       console.log('🔧 Testing context source creation:');
       const newSource = new InMemoryTextInputContextSource({
+        name: 'New context source',
         text: 'This is a test text input for the context source.',
         description: 'Test description',
       });

--- a/packages/context-sources/common/src/registry.ts
+++ b/packages/context-sources/common/src/registry.ts
@@ -9,8 +9,10 @@ export interface ContextSourceRegistration {
    * Factory that creates a new instance of the context source.
    */
   factory: ({
+    name,
     configuration,
   }: {
+    name: string;
     configuration: Record<string, string>;
   }) => ContextSource;
 }
@@ -35,9 +37,11 @@ class ContextSourceRegistry {
 
   createInstance({
     type,
+    name,
     configuration,
   }: {
     type: string;
+    name: string;
     configuration: Record<string, string>;
   }): ContextSource {
     const registration = this.sources.get(type);
@@ -45,7 +49,7 @@ class ContextSourceRegistry {
       throw new Error(`Context source ${type} not found`);
     }
 
-    return registration.factory({ configuration });
+    return registration.factory({ name, configuration });
   }
 }
 


### PR DESCRIPTION
OpenAI indexes tools by name so we need to pass the user-defined name in.